### PR TITLE
More mod support

### DIFF
--- a/common/src/main/resources/data/byg/separated_leaves/araucaria.json
+++ b/common/src/main/resources/data/byg/separated_leaves/araucaria.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:araucaria_leaves"],
+  "logs": ["#byg:pine_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/aspen.json
+++ b/common/src/main/resources/data/byg/separated_leaves/aspen.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:aspen_leaves"],
+  "logs": ["#byg:aspen_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/baobab.json
+++ b/common/src/main/resources/data/byg/separated_leaves/baobab.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:baobab_leaves", "byg:ripe_baobab_leaves", "byg:flowering_baobab_leaves"],
+  "logs": ["#byg:baobab_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/blue_enchanted.json
+++ b/common/src/main/resources/data/byg/separated_leaves/blue_enchanted.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:blue_enchanted_leaves"],
+  "logs": ["#byg:blue_enchanted_logs", "byg:imbued_blue_enchanted_log"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/blue_spruce.json
+++ b/common/src/main/resources/data/byg/separated_leaves/blue_spruce.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:blue_spruce_leaves"],
+  "logs": ["#minecraft:spruce_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/brown_birch.json
+++ b/common/src/main/resources/data/byg/separated_leaves/brown_birch.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:brown_birch_leaves"],
+  "logs": ["#minecraft:birch_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/brown_oak.json
+++ b/common/src/main/resources/data/byg/separated_leaves/brown_oak.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:brown_oak_leaves"],
+  "logs": ["#minecraft:oak_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/brown_zelkova.json
+++ b/common/src/main/resources/data/byg/separated_leaves/brown_zelkova.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:brown_zelkova_leaves"],
+  "logs": ["#byg:zelkova_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/cika.json
+++ b/common/src/main/resources/data/byg/separated_leaves/cika.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:cika_leaves"],
+  "logs": ["#byg:cika_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/cypress.json
+++ b/common/src/main/resources/data/byg/separated_leaves/cypress.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:cypress_leaves"],
+  "logs": ["#byg:cypress_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/ebony.json
+++ b/common/src/main/resources/data/byg/separated_leaves/ebony.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:ebony_leaves"],
+  "logs": ["#byg:ebony_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/ether.json
+++ b/common/src/main/resources/data/byg/separated_leaves/ether.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:ether_leaves"],
+  "logs": ["#byg:ether_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/fir.json
+++ b/common/src/main/resources/data/byg/separated_leaves/fir.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:fir_leaves"],
+  "logs": ["#byg:fir_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/firecracker.json
+++ b/common/src/main/resources/data/byg/separated_leaves/firecracker.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:firecracker_leaves"],
+  "logs": ["#minecraft:oak_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/green_enchanted.json
+++ b/common/src/main/resources/data/byg/separated_leaves/green_enchanted.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:green_enchanted_leaves"],
+  "logs": ["#byg:green_enchanted_logs", "byg:imbued_green_enchanted_log"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/holly.json
+++ b/common/src/main/resources/data/byg/separated_leaves/holly.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:holly_berry_leaves", "byg:holly_leaves"],
+  "logs": ["#byg:holly_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/indigo_jacaranda.json
+++ b/common/src/main/resources/data/byg/separated_leaves/indigo_jacaranda.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:indigo_jacaranda_leaves", "byg:flowering_indigo_jacaranda_leaves"],
+  "logs": ["#byg:jacaranda_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/jacaranda.json
+++ b/common/src/main/resources/data/byg/separated_leaves/jacaranda.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:flowering_jacaranda_leaves", "byg:jacaranda_leaves"],
+  "logs": ["#byg:jacaranda_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/joshua.json
+++ b/common/src/main/resources/data/byg/separated_leaves/joshua.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:joshua_leaves", "byg:flowering_joshua_leaves", "byg:ripe_joshua_leaves"],
+  "logs": ["#minecraft:oak_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/lament.json
+++ b/common/src/main/resources/data/byg/separated_leaves/lament.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:lament_leaves"],
+  "logs": ["#byg:lament_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/mahogany.json
+++ b/common/src/main/resources/data/byg/separated_leaves/mahogany.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:mahogany_leaves"],
+  "logs": ["#byg:mahogany_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/maple.json
+++ b/common/src/main/resources/data/byg/separated_leaves/maple.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:maple_leaves"],
+  "logs": ["#byg:maple_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/nightshade.json
+++ b/common/src/main/resources/data/byg/separated_leaves/nightshade.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:nightshade_leaves", "byg:flowering_nightshade_leaves"],
+  "logs": ["#byg:nightshade_logs", "byg:imbued_nightshade_log"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/orange_birch.json
+++ b/common/src/main/resources/data/byg/separated_leaves/orange_birch.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:orange_birch_leaves"],
+  "logs": ["#minecraft:birch_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/orange_oak.json
+++ b/common/src/main/resources/data/byg/separated_leaves/orange_oak.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:orange_oak_leaves"],
+  "logs": ["#minecraft:oak_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/orange_spruce.json
+++ b/common/src/main/resources/data/byg/separated_leaves/orange_spruce.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:orange_spruce_leaves"],
+  "logs": ["#minecraft:spruce_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/orchard.json
+++ b/common/src/main/resources/data/byg/separated_leaves/orchard.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:orchard_leaves", "byg:flowering_orchard_leaves", "byg:ripe_orchard_leaves"],
+  "logs": ["#minecraft:oak_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/palm.json
+++ b/common/src/main/resources/data/byg/separated_leaves/palm.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:palm_leaves"],
+  "logs": ["#byg:palm_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/palo_verde.json
+++ b/common/src/main/resources/data/byg/separated_leaves/palo_verde.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:palo_verde_leaves", "byg:flowering_palo_verde_leaves"],
+  "logs": ["#byg:palo_verde_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/pine.json
+++ b/common/src/main/resources/data/byg/separated_leaves/pine.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:pine_leaves"],
+  "logs": ["#byg:pine_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/pink_cherry.json
+++ b/common/src/main/resources/data/byg/separated_leaves/pink_cherry.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:pink_cherry_leaves"],
+  "logs": ["#byg:cherry_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/rainbow_eucalyptus.json
+++ b/common/src/main/resources/data/byg/separated_leaves/rainbow_eucalyptus.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:rainbow_eucalyptus_leaves"],
+  "logs": ["#byg:rainbow_eucalyptus_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/red_birch.json
+++ b/common/src/main/resources/data/byg/separated_leaves/red_birch.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:red_birch_leaves"],
+  "logs": ["#minecraft:birch_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/red_maple.json
+++ b/common/src/main/resources/data/byg/separated_leaves/red_maple.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:red_maple_leaves"],
+  "logs": ["#byg:maple_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/red_oak.json
+++ b/common/src/main/resources/data/byg/separated_leaves/red_oak.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:red_oak_leaves"],
+  "logs": ["#minecraft:oak_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/red_spruce.json
+++ b/common/src/main/resources/data/byg/separated_leaves/red_spruce.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:red_spruce_leaves"],
+  "logs": ["#minecraft:spruce_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/redwood.json
+++ b/common/src/main/resources/data/byg/separated_leaves/redwood.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:redwood_leaves"],
+  "logs": ["#byg:redwood_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/silver_maple.json
+++ b/common/src/main/resources/data/byg/separated_leaves/silver_maple.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:silver_maple_leaves"],
+  "logs": ["#byg:maple_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/skyris.json
+++ b/common/src/main/resources/data/byg/separated_leaves/skyris.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:skyris_leaves", "byg:flowering_skyris_leaves", "byg:green_apple_skyris_leaves"],
+  "logs": ["#byg:skyris_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/white_cherry.json
+++ b/common/src/main/resources/data/byg/separated_leaves/white_cherry.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:white_cherry_leaves"],
+  "logs": ["#byg:cherry_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/white_mangrove.json
+++ b/common/src/main/resources/data/byg/separated_leaves/white_mangrove.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:white_mangrove_leaves"],
+  "logs": ["#byg:white_mangrove_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/willow.json
+++ b/common/src/main/resources/data/byg/separated_leaves/willow.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:willow_leaves"],
+  "logs": ["#byg:willow_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/witch_hazel.json
+++ b/common/src/main/resources/data/byg/separated_leaves/witch_hazel.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:witch_hazel_leaves", "byg:blooming_witch_hazel_leaves"],
+  "logs": ["#byg:witch_hazel_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/withering_oak.json
+++ b/common/src/main/resources/data/byg/separated_leaves/withering_oak.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:withering_oak_leaves"],
+  "logs": ["#byg:withering_oak_logs", "byg:stripped_oak_log", "byg:stripped_oak_wood"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/yellow_birch.json
+++ b/common/src/main/resources/data/byg/separated_leaves/yellow_birch.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:yellow_birch_leaves"],
+  "logs": ["#minecraft:birch_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/yellow_spruce.json
+++ b/common/src/main/resources/data/byg/separated_leaves/yellow_spruce.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:yellow_spruce_leaves"],
+  "logs": ["#minecraft:spruce_logs"]
+}

--- a/common/src/main/resources/data/byg/separated_leaves/zelkova.json
+++ b/common/src/main/resources/data/byg/separated_leaves/zelkova.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["byg:zelkova_leaves"],
+  "logs": ["#byg:zelkova_logs"]
+}

--- a/common/src/main/resources/data/hexcasting/separated_leaves/edified.json
+++ b/common/src/main/resources/data/hexcasting/separated_leaves/edified.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["hexcasting:amethyst_edified_leaves", "hexcasting:aventurine_edified_leaves", "hexcasting:citrine_edified_leaves"],
+  "logs": ["#hexcasting:edified_logs"]
+}

--- a/common/src/main/resources/data/malum/separated_leaves/runewood.json
+++ b/common/src/main/resources/data/malum/separated_leaves/runewood.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["malum:runewood_leaves"],
+  "logs": ["#malum:runewood_logs"]
+}

--- a/common/src/main/resources/data/malum/separated_leaves/soulwood.json
+++ b/common/src/main/resources/data/malum/separated_leaves/soulwood.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["malum:soulwood_leaves"],
+  "logs": ["#malum:soulwood_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/alpha.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/alpha.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:alpha_leaves"],
+  "logs": ["regions_unexplored:alpha_log"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/apple_oak.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/apple_oak.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:apple_oak_leaves", "minecraft:oak_leaves"],
+  "logs": ["#minecraft:oak_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/bamboo.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/bamboo.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:bamboo_leaves"],
+  "logs": ["#regions_unexplored:bamboo_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/baobab.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/baobab.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:baobab_leaves"],
+  "logs": ["#regions_unexplored:baobab_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/blackwood.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/blackwood.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:blackwood_leaves"],
+  "logs": ["#regions_unexplored:blackwood_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/cherry.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/cherry.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:cherry_leaves"],
+  "logs": ["#regions_unexplored:cherry_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/cypress.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/cypress.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:cypress_leaves"],
+  "logs": ["#regions_unexplored:cypress_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/dead.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/dead.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:dead_leaves"],
+  "logs": ["#regions_unexplored:dead_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/dead_pine.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/dead_pine.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:dead_pine_leaves"],
+  "logs": ["#regions_unexplored:dead_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/eucalyptus.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/eucalyptus.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:eucalyptus_leaves"],
+  "logs": ["#regions_unexplored:eucalyptus_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/flowering.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/flowering.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:flowering_leaves", "minecraft:oak_leaves"],
+  "logs": ["#minecraft:oak_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/golden_larch.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/golden_larch.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:golden_larch_leaves"],
+  "logs": ["#regions_unexplored:larch_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/green_maple.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/green_maple.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:green_maple_leaves"],
+  "logs": ["#regions_unexplored:maple_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/joshua.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/joshua.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:joshua_leaves"],
+  "logs": ["#regions_unexplored:joshua_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/larch.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/larch.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:larch_leaves"],
+  "logs": ["#regions_unexplored:larch_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/mauve.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/mauve.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:mauve_leaves"],
+  "logs": ["#regions_unexplored:mauve_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/orange_maple.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/orange_maple.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:orange_maple_leaves"],
+  "logs": ["#regions_unexplored:maple_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/palm.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/palm.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:palm_leaves"],
+  "logs": ["#regions_unexplored:palm_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/pine.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/pine.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:pine_leaves"],
+  "logs": ["#regions_unexplored:pine_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/pink_cherry.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/pink_cherry.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:pink_cherry_leaves"],
+  "logs": ["#regions_unexplored:cherry_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/red_cherry.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/red_cherry.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:red_cherry_leaves"],
+  "logs": ["#regions_unexplored:cherry_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/red_maple.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/red_maple.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:red_maple_leaves"],
+  "logs": ["#regions_unexplored:maple_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/redwood.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/redwood.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:redwood_leaves"],
+  "logs": ["#regions_unexplored:redwood_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/sculkwood.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/sculkwood.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:sculkwood_leaves"],
+  "logs": ["#regions_unexplored:sculkwood_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/silver_birch.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/silver_birch.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:silver_birch_leaves"],
+  "logs": ["#minecraft:birch_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/white_cherry.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/white_cherry.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:white_cherry_leaves"],
+  "logs": ["#regions_unexplored:cherry_logs"]
+}

--- a/common/src/main/resources/data/regions_unexplored/separated_leaves/willow.json
+++ b/common/src/main/resources/data/regions_unexplored/separated_leaves/willow.json
@@ -1,0 +1,4 @@
+{
+  "leaves": ["regions_unexplored:willow_leaves"],
+  "logs": ["#regions_unexplored:willow_logs"]
+}


### PR DESCRIPTION
This PR adds support for [Hex Casting](https://modrinth.com/mod/hex-casting), [Malum](https://www.curseforge.com/minecraft/mc-mods/malum), [Oh The Biomes You'll Go](https://modrinth.com/mod/biomesyougo), and [Regions Unexplored](https://modrinth.com/mod/regions-unexplored).

This should be able to be merged as-is into the 1.20.1 branch as well, but I haven't tested it - notably, Hex Casting and Malum haven't updated past 1.19.2 yet, while BYG hasn't updated past 1.19.4.

Fixes #1.

(for reference, I used a Python script to generate the data files after manually making a list of trees, leaves, and logs for each mod. ([script](https://gist.github.com/unilock/a1396e3b52d8ff2109b9bb7a454d315a#file-run-py)) ([example list](https://gist.github.com/unilock/a1396e3b52d8ff2109b9bb7a454d315a#file-malum-txt)))

I tried adding support for [Spectrum](https://modrinth.com/mod/spectrum) as well, but it seems it handles its leaves differently, as they still allowed *any* log to prevent them from decaying, instead of only those defined by this mod.