### PR TITLE
Add mismatch leaves allowed structure tag

### DIFF
--- a/common/src/main/java/nl/teamdiopside/separatedleaves/SeparatedLeaves.java
+++ b/common/src/main/java/nl/teamdiopside/separatedleaves/SeparatedLeaves.java
@@ -1,12 +1,17 @@
 package nl.teamdiopside.separatedleaves;
 
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.levelgen.structure.Structure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SeparatedLeaves {
     public static final String MOD_ID = "separatedleaves";
     public static final Logger LOGGER = LoggerFactory.getLogger("Separated Leaves");
+    public static final TagKey<Structure> ALLOW_MISMATCHED_LEAVES_STRUCTURES = TagKey.create(Registries.STRUCTURE, new ResourceLocation(MOD_ID, "allow_mismatched_leaves_structures"));
 
     public static MinecraftServer minecraftServer = null;
     

--- a/common/src/main/java/nl/teamdiopside/separatedleaves/mixin/LeavesBlockMixin.java
+++ b/common/src/main/java/nl/teamdiopside/separatedleaves/mixin/LeavesBlockMixin.java
@@ -2,12 +2,16 @@ package nl.teamdiopside.separatedleaves.mixin;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.StructureManager;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.LeavesBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
+import net.minecraft.world.level.levelgen.structure.StructureStart;
 import nl.teamdiopside.separatedleaves.Reload;
+import nl.teamdiopside.separatedleaves.SeparatedLeaves;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -21,6 +25,15 @@ public abstract class LeavesBlockMixin {
 
     @Inject(method = "updateDistance", at = @At("HEAD"), cancellable = true)
     private static void updateDistance(BlockState blockState, LevelAccessor levelAccessor, BlockPos blockPos, CallbackInfoReturnable<BlockState> cir) {
+        // Skip logic for structures that are tagged as allowing mismatched leaves
+        if (levelAccessor instanceof ServerLevel serverLevel) {
+            StructureManager structureManager = serverLevel.structureManager();
+            StructureStart detectedStructure = structureManager.getStructureWithPieceAt(blockPos, SeparatedLeaves.ALLOW_MISMATCHED_LEAVES_STRUCTURES);
+            if (detectedStructure.isValid()) {
+                return;
+            }
+        }
+
         boolean hasFile = false;
         int i = 7;
         BlockPos.MutableBlockPos mutableBlockPos = new BlockPos.MutableBlockPos();

--- a/common/src/main/resources/data/separatedleaves/tags/worldgen/structure/allow_mismatched_leaves_structures.json
+++ b/common/src/main/resources/data/separatedleaves/tags/worldgen/structure/allow_mismatched_leaves_structures.json
@@ -1,0 +1,13 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "#the_bumblezone:sempiternal_sanctums",
+      "required": false
+    },
+    {
+      "id": "the_bumblezone:hanging_garden",
+      "required": false
+    }
+  ]
+}


### PR DESCRIPTION
Any structure in this tag will be allowed to have leaves that do not match the logs. This allows players and other modders to tag structures where mismatched leaves/logs are intended and should not decay.

Name of tag can be changed. I added two bumblezone entries in the tag as an example. You can keep the entries or remove them. The tag entries are optional tag entries so they do not error even if bumblezone is not on.

Fixes https://github.com/TeamDiopside/SeparatedLeaves/issues/4