### PR TITLE
Delete quark's pink_blossom.json as that tree no longer exists

### DIFF
--- a/common/src/main/resources/data/quark/separated_leaves/pink_blossom.json
+++ b/common/src/main/resources/data/quark/separated_leaves/pink_blossom.json
@@ -1,4 +1,0 @@
-{
-  "leaves": ["quark:pink_blossom_leaves"],
-  "logs": ["#quark:blossom_logs"]
-}


### PR DESCRIPTION
Now that Quark 1.20.1 is officially out, the Pink Blossom tree is officially out of the mod. Deleting the associated compat file prevents cluttering the log and ever so slightly improves loading times and file sizes.
Resolves #8

